### PR TITLE
Fix: Prevent empty value for Select.Item in cluster leader selection

### DIFF
--- a/app/(dashboard)/clusters/new/page.tsx
+++ b/app/(dashboard)/clusters/new/page.tsx
@@ -221,8 +221,8 @@ export default function NewClusterPage() {
       const submitData = {
         ...data,
         centerId: data.assignToHQ ? null : data.centerId,
-        // If leaderId is empty string, set to null
-        leaderId: data.leaderId && data.leaderId.trim() !== "" ? data.leaderId : null
+        // If leaderId is empty string or "@none", set to null
+        leaderId: data.leaderId && data.leaderId.trim() !== "" && data.leaderId !== "@none" ? data.leaderId : null
       };
 
       const response = await fetch("/api/clusters", {
@@ -548,7 +548,7 @@ export default function NewClusterPage() {
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
-                        <SelectItem value="">No leader assigned yet</SelectItem>
+                        <SelectItem value="@none">No leader assigned yet</SelectItem>
                         {members.map((member) => (
                           <SelectItem key={member._id} value={member._id}>
                             {member.firstName} {member.lastName}


### PR DESCRIPTION
Addresses a runtime error where Select.Item was receiving an empty string value, which is not allowed.

- I modified the 'No leader assigned yet' SelectItem in `app/(dashboard)/clusters/new/page.tsx` to use a value of '@none' instead of an empty string.
- I updated the `onSubmit` handler to convert '@none' or an empty string for `leaderId` to `null` before submitting the form data, ensuring backend compatibility.
- This change ensures the placeholder for the leader selection displays correctly and prevents the runtime error.