### PR TITLE
Fix: Resolve linting errors in dashboard and API routes (Part 1)

### DIFF
--- a/app/(dashboard)/centers/[id]/dashboard/page.tsx
+++ b/app/(dashboard)/centers/[id]/dashboard/page.tsx
@@ -25,9 +25,7 @@ import {
   ArrowLeft,
   ChevronRight
 } from 'lucide-react';
-// import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
-// import { getInitials } from "@/lib/utils";
 import { useAuthStore } from "@/lib/store";
 import { useSession } from "next-auth/react";
 
@@ -209,7 +207,7 @@ export default function CenterDashboardPage() {
       const eventsData = await eventsResponse.json();
       setEvents(eventsData.events || []);
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching center data:", error);
       toast({
         title: "Error",
@@ -591,7 +589,7 @@ export default function CenterDashboardPage() {
             <div className="text-center py-10">
               <Network className="mx-auto h-12 w-12 text-gray-400 mb-4" />
               <h3 className="text-lg font-medium mb-2">No Clusters Found</h3>
-              <p className="text-gray-500 mb-4">This center doesn't have any clusters yet.</p>
+              <p className="text-gray-500 mb-4">This center doesn&apos;t have any clusters yet.</p>
               <Button asChild>
                 <Link href={`/clusters/new?centerId=${center._id}`}>
                   Create First Cluster

--- a/app/(dashboard)/centers/[id]/members/page.tsx
+++ b/app/(dashboard)/centers/[id]/members/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { 
   Card, 
   CardContent, 
@@ -15,13 +16,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { 
   Users, 
-  UserCheck, 
-  Calendar, 
   Building, 
-  Network, 
-  MapPin, 
-  ArrowLeft,
-  ChevronRight
+  ArrowLeft
 } from 'lucide-react';
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
@@ -97,7 +93,7 @@ export default function CenterMembersPage() {
       const membersData = await membersResponse.json();
       setMembers(membersData.members || []);
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching center members:", error);
       toast({
         title: "Error",
@@ -210,7 +206,7 @@ export default function CenterMembersPage() {
             <div className="text-center py-10">
               <Users className="mx-auto h-12 w-12 text-gray-400 mb-4" />
               <h3 className="text-lg font-medium mb-2">No Members Found</h3>
-              <p className="text-gray-500 mb-4">This center doesn't have any members yet.</p>
+              <p className="text-gray-500 mb-4">This center doesn&apos;t have any members yet.</p>
               <Button asChild>
                 <Link href={`/centers/${centerId}/members/add`}>
                   Add First Member
@@ -225,7 +221,7 @@ export default function CenterMembersPage() {
                     <div className="flex items-center gap-3">
                       <Avatar className="h-10 w-10">
                         {member.profileImage ? (
-                          <img src={member.profileImage} alt={`${member.firstName} ${member.lastName}`} />
+                          <Image src={member.profileImage} alt={`${member.firstName} ${member.lastName}`} width={40} height={40} className="rounded-full" />
                         ) : (
                           <AvatarFallback>{getInitials(member.firstName, member.lastName)}</AvatarFallback>
                         )}

--- a/app/(dashboard)/centers/[id]/page.tsx
+++ b/app/(dashboard)/centers/[id]/page.tsx
@@ -23,7 +23,8 @@ import {
   Edit, 
   Plus,
   ArrowLeft,
-  AlertTriangle
+  AlertTriangle,
+  Calendar
 } from "lucide-react"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { useToast } from "@/hooks/use-toast"
@@ -133,7 +134,7 @@ export default function CenterDetailPage() {
         setClusters(clustersData.clusters || [])
       }
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching center details:", error)
       toast({
         title: "Error",

--- a/app/(dashboard)/centers/new/page.tsx
+++ b/app/(dashboard)/centers/new/page.tsx
@@ -19,7 +19,6 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
@@ -93,7 +92,7 @@ export default function NewCenterPage() {
       
       // Redirect to the new center's page
       router.push(`/centers/${result.center._id}`)
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error creating center:", error)
       toast({
         title: "Error",

--- a/app/(dashboard)/centers/page.tsx
+++ b/app/(dashboard)/centers/page.tsx
@@ -131,7 +131,7 @@ export default function CentersPage() {
       setCenters(data.centers || [])
       setPagination(data.paginationInfo || { page, limit: pagination.limit, total: 0, pages: 0 })
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching centers:", error)
       toast({
         title: "Error",

--- a/app/(dashboard)/clusters/[id]/dashboard/page.tsx
+++ b/app/(dashboard)/clusters/[id]/dashboard/page.tsx
@@ -26,9 +26,7 @@ import {
   ChevronRight,
   Home 
 } from 'lucide-react';
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { useToast } from "@/hooks/use-toast";
-import { getInitials } from "@/lib/utils";
 import { useAuthStore } from "@/lib/store";
 import { useSession } from "next-auth/react";
 
@@ -197,7 +195,7 @@ export default function ClusterDashboardPage() {
       const eventsData = await eventsResponse.json();
       setEvents(eventsData.events || []);
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching cluster data:", error);
       toast({
         title: "Error",
@@ -332,7 +330,7 @@ export default function ClusterDashboardPage() {
       <div className="text-center py-10">
         <Layers className="mx-auto h-12 w-12 text-red-400 mb-4" />
         <h3 className="text-lg font-medium mb-2">Permission Denied</h3>
-        <p className="text-gray-500 mb-4">You do not have permission to view this cluster's dashboard.</p>
+        <p className="text-gray-500 mb-4">You do not have permission to view this cluster&apos;s dashboard.</p>
         <Button onClick={() => router.push("/clusters")}>Back to Clusters</Button>
       </div>
     );
@@ -593,7 +591,7 @@ export default function ClusterDashboardPage() {
             <div className="text-center py-10">
               <Users className="mx-auto h-12 w-12 text-gray-400 mb-4" />
               <h3 className="text-lg font-medium mb-2">No Small Groups Found</h3>
-              <p className="text-gray-500 mb-4">This cluster doesn't have any small groups yet.</p>
+              <p className="text-gray-500 mb-4">This cluster doesn&apos;t have any small groups yet.</p>
               <Button asChild>
                 <Link href={`/groups/new?clusterId=${cluster._id}`}>
                   Create First Small Group

--- a/app/(dashboard)/clusters/[id]/page.tsx
+++ b/app/(dashboard)/clusters/[id]/page.tsx
@@ -96,12 +96,12 @@ export default function ClusterDetailPage() {
 
   const [cluster, setCluster] = useState<Cluster | null>(null)
   const [smallGroups, setSmallGroups] = useState<SmallGroup[]>([]) 
-  const [members, setMembers] = useState<Member[]>([]) 
+  const [members, _setMembers] = useState<Member[]>([]) 
   const [isLoading, setIsLoading] = useState(true)
 
   const canEditCluster = user && cluster ? checkPermission(user, ["HQ_ADMIN", "CENTER_ADMIN", "CLUSTER_LEADER"], cluster.centerId?._id, cluster._id) : false;
   const canCreateSmallGroup = user && cluster ? checkPermission(user, ["HQ_ADMIN", "CENTER_ADMIN", "CLUSTER_LEADER"], cluster.centerId?._id, cluster._id) : false;
-  const canAddMemberToCluster = user && cluster ? checkPermission(user, ["HQ_ADMIN", "CENTER_ADMIN", "CLUSTER_LEADER"], cluster.centerId?._id, cluster._id) : false;
+  // const canAddMemberToCluster = user && cluster ? checkPermission(user, ["HQ_ADMIN", "CENTER_ADMIN", "CLUSTER_LEADER"], cluster.centerId?._id, cluster._id) : false;
 
   const fetchClusterDetails = useCallback(async () => {
     if (!user || !clusterIdFromParams) return;
@@ -137,7 +137,7 @@ export default function ClusterDetailPage() {
       //   setMembers(membersData.members || [])
       // }
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching cluster details:", error)
       toast({
         title: "Error",

--- a/app/(dashboard)/clusters/new/page.tsx
+++ b/app/(dashboard)/clusters/new/page.tsx
@@ -107,7 +107,7 @@ export default function NewClusterPage() {
   const [centers, setCenters] = useState<Array<{ _id: string; name: string }>>([])
   const [members, setMembers] = useState<Array<{ _id: string; firstName: string; lastName: string }>>([])
   const [isLoadingCenters, setIsLoadingCenters] = useState(true)
-  const [isLoadingMembers, setIsLoadingMembers] = useState(true)
+  const [_isLoadingMembers, setIsLoadingMembers] = useState(true)
 
   // Get centerId from URL if available
   const centerIdFromUrl = searchParams.get("centerId")
@@ -203,7 +203,7 @@ export default function NewClusterPage() {
       fetchCenters()
       fetchMembers()
     }
-  }, [status])
+  }, [status, fetchCenters, fetchMembers])
 
   // Handle assignment toggle
   const handleAssignmentToggle = (value: boolean) => {
@@ -247,7 +247,7 @@ export default function NewClusterPage() {
       
       // Redirect to the new cluster's page
       router.push(`/clusters/${result.cluster._id}`)
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error creating cluster:", error)
       toast({
         title: "Error",

--- a/app/(dashboard)/clusters/page.tsx
+++ b/app/(dashboard)/clusters/page.tsx
@@ -147,7 +147,7 @@ export default function ClustersPage() {
         setParentCenterName(data.clusters[0].centerId?.name || null);
       }
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching clusters:", error)
       toast({
         title: "Error",


### PR DESCRIPTION
This commit addresses a subset of the ESLint and TypeScript errors identified in the build log.

Changes made:

- Resolved linting errors in the following files:
    - `app/(dashboard)/centers/[id]/dashboard/page.tsx`: Removed unused imports (`Avatar`, `AvatarFallback`, `getInitials`), typed an error object (`error: any` to `error: Error`), and escaped an apostrophe.
    - `app/(dashboard)/centers/[id]/members/page.tsx`: Removed unused imports (`UserCheck`, `Calendar`, `Network`, `MapPin`, `ChevronRight`), typed an error object, escaped an apostrophe, and replaced `<img>` with `next/image`.
    - `app/(dashboard)/centers/[id]/page.tsx`: Typed an error object and imported `Calendar` from `lucide-react`.
    - `app/(dashboard)/centers/new/page.tsx`: Removed unused import (`CardFooter`) and typed an error object. Noted false positives for unescaped quotes.
    - `app/(dashboard)/centers/page.tsx`: Typed an error object.
    - `app/(dashboard)/clusters/[id]/dashboard/page.tsx`: Removed unused imports (`Avatar`, `AvatarFallback`, `getInitials`), typed an error object, and escaped apostrophes.
    - `app/(dashboard)/clusters/[id]/page.tsx`: Renamed unused state setter `setMembers` to `_setMembers`, commented out unused variable `canAddMemberToCluster`, and typed an error object.
    - `app/(dashboard)/clusters/new/page.tsx`: Renamed unused state variable `isLoadingMembers` to `_isLoadingMembers`, added missing dependencies to `useEffect` hook, typed an error object. Noted false positives for unescaped quotes.
    - `app/(dashboard)/clusters/page.tsx`: Typed an error object.

Work is ongoing to resolve all reported linting issues and address the functionality of the follow-up page as per the original issue. This commit represents the completion of the first 9 steps.