### PR TITLE
Fix: Resolve linting errors in dashboard and API routes (Part 2)

### DIFF
--- a/app/(dashboard)/flyers/page.tsx
+++ b/app/(dashboard)/flyers/page.tsx
@@ -184,7 +184,7 @@ export default function FlyersPage() {
     router.push("/dashboard/flyers");
   };
 
-  const updateUrlParams = (params: Record<string, any>) => {
+  const updateUrlParams = (params: Record<string, string | number | null>) => {
     const newParams = new URLSearchParams(searchParams.toString());
     
     Object.entries(params).forEach(([key, value]) => {

--- a/app/(dashboard)/follow-ups/[id]/page.tsx
+++ b/app/(dashboard)/follow-ups/[id]/page.tsx
@@ -1293,8 +1293,7 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle,
-  DialogTrigger
+  DialogTitle
 } from "@/components/ui/dialog"
 import { Checkbox } from "@/components/ui/checkbox"
 
@@ -1362,7 +1361,7 @@ const clusters = [
 
 export default function FollowUpDetailPage() {
   const params = useParams<{ id: string }>();
-  const router = useRouter();
+  // const router = useRouter();
   const { toast } = useToast();
   
   const [followUp, setFollowUp] = useState<FollowUp | null>(null);
@@ -1469,7 +1468,7 @@ export default function FollowUpDetailPage() {
         if (mockFollowUp.nextFollowUpDate) {
           setNextFollowUpDate(new Date(mockFollowUp.nextFollowUpDate).toISOString().split('T')[0]);
         }
-      } catch (error) {
+      } catch (error: Error) {
         console.error("Error fetching follow-up:", error);
         toast({
           title: "Error",
@@ -1492,7 +1491,7 @@ export default function FollowUpDetailPage() {
     setResponseCategory(newCategory as FollowUp['responseCategory']);
   };
   
-  const handleNewAttemptChange = (field: keyof typeof newAttempt, value: any) => {
+  const handleNewAttemptChange = (field: keyof typeof newAttempt, value: string | boolean | string[]) => {
     setNewAttempt(prev => ({
       ...prev,
       [field]: value
@@ -1704,8 +1703,8 @@ export default function FollowUpDetailPage() {
       }
       
       const selectedChannels = Object.entries(messageData.channels)
-        .filter(([_, selected]) => selected)
-        .map(([channel, _]) => channel);
+        .filter(([, selected]) => selected)
+        .map(([channel]) => channel);
       
       if (selectedChannels.length === 0) {
         toast({

--- a/app/(dashboard)/follow-ups/new/page.tsx
+++ b/app/(dashboard)/follow-ups/new/page.tsx
@@ -13,7 +13,6 @@ import {
   Card, 
   CardContent, 
   CardDescription, 
-  CardFooter, 
   CardHeader, 
   CardTitle 
 } from "@/components/ui/card"
@@ -142,7 +141,7 @@ export default function NewFollowUpPage() {
     },
   });
   
-  async function onSubmitNewAttendee(values: z.infer<typeof newAttendeeSchema>) {
+  async function onSubmitNewAttendee(_values: z.infer<typeof newAttendeeSchema>) {
     try {
       setIsSubmitting(true);
       
@@ -190,7 +189,7 @@ export default function NewFollowUpPage() {
     }
   }
   
-  async function onSubmitMember(values: z.infer<typeof memberSchema>) {
+  async function onSubmitMember(_values: z.infer<typeof memberSchema>) {
     try {
       setIsSubmitting(true);
       

--- a/app/(dashboard)/follow-ups/page.tsx
+++ b/app/(dashboard)/follow-ups/page.tsx
@@ -1471,7 +1471,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Pagination } from "@/components/ui/pagination"
 import { Badge } from "@/components/ui/badge"
 import { 
-  Search, Plus, Filter, UserCheck, ChevronRight, X, Mail, Phone, 
+  Search, Plus, ChevronRight, X, Mail, Phone, 
   Calendar, AlertCircle, CheckCircle, XCircle, Clock 
 } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
@@ -1550,7 +1550,7 @@ export default function FollowUpsPage() {
     });
     
     fetchFollowUps(page, search, status, responseCategory, personType, assignedTo);
-  }, [searchParams]);
+  }, [searchParams, fetchFollowUps]);
 
   const fetchFollowUps = async (
     page: number, 
@@ -1564,7 +1564,7 @@ export default function FollowUpsPage() {
       setIsLoading(true);
       
       // Build query string
-      let queryParams = new URLSearchParams();
+      const queryParams = new URLSearchParams();
       queryParams.append("page", page.toString());
       queryParams.append("limit", pagination.limit.toString());
       
@@ -1608,7 +1608,7 @@ export default function FollowUpsPage() {
         total: 35, // Mock total
         pages: 4,  // Mock pages
       });
-    } catch (error) {
+    } catch (error: Error) {
       console.error("Error fetching follow-ups:", error);
       toast({
         title: "Error",
@@ -1651,7 +1651,7 @@ export default function FollowUpsPage() {
     router.push("/follow-ups");
   };
 
-  const updateUrlParams = (params: Record<string, any>) => {
+  const updateUrlParams = (params: Record<string, string | number | null>) => {
     const newParams = new URLSearchParams(searchParams.toString());
     
     Object.entries(params).forEach(([key, value]) => {

--- a/app/(dashboard)/groups/[id]/dashboard/page.tsx
+++ b/app/(dashboard)/groups/[id]/dashboard/page.tsx
@@ -119,7 +119,7 @@ export default function GroupDashboardPage() {
       const eventsData = await eventsResponse.json();
       setEvents(eventsData.events || []);
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching group data:", error);
       toast({
         title: "Error",
@@ -212,7 +212,7 @@ export default function GroupDashboardPage() {
       <div className="text-center py-10">
         <Network className="mx-auto h-12 w-12 text-red-400 mb-4" />
         <h3 className="text-lg font-medium mb-2">Permission Denied</h3>
-        <p className="text-gray-500 mb-4">You do not have permission to view this small group's dashboard.</p>
+        <p className="text-gray-500 mb-4">You do not have permission to view this small group&apos;s dashboard.</p>
         <Button onClick={() => router.push("/groups")}>Back to Small Groups</Button>
       </div>
     );

--- a/app/(dashboard)/members/page.tsx
+++ b/app/(dashboard)/members/page.tsx
@@ -132,7 +132,7 @@ export default function MembersPage() {
     })
     
     fetchMembers(page, search, clusterId, smallGroupId, gender)
-  }, [searchParams])
+  }, [searchParams, fetchMembers])
 
   const fetchMembers = async (
     page: number, 

--- a/app/(dashboard)/members/spiritual-growth-tab.tsx
+++ b/app/(dashboard)/members/spiritual-growth-tab.tsx
@@ -328,7 +328,7 @@ export function MemberSpiritualGrowthTab({ memberId }: { memberId: string }) {
 
   useEffect(() => {
     fetchSpiritualGrowth()
-  }, [memberId])
+  }, [memberId, fetchSpiritualGrowth])
 
   const fetchSpiritualGrowth = async () => {
     try {
@@ -347,12 +347,13 @@ export function MemberSpiritualGrowthTab({ memberId }: { memberId: string }) {
         const stagesArray: SpiritualGrowthStage[] = []
         
         if (data.data) {
-          Object.entries(data.data).forEach(([key, value]: [string, any]) => {
-            if (value && value.date) {
+          Object.entries(data.data).forEach(([key, value]: [string, unknown]) => {
+            // Type guard for value
+            if (value && typeof value === 'object' && 'date' in value) {
               stagesArray.push({
                 stage: key,
-                date: value.date,
-                notes: value.notes
+                date: (value as { date: string }).date,
+                notes: (value as { notes?: string }).notes
               })
             }
           })

--- a/app/(dashboard)/small-groups/[id]/page.tsx
+++ b/app/(dashboard)/small-groups/[id]/page.tsx
@@ -119,7 +119,7 @@ export default function SmallGroupDetailPage() {
         setMembers(membersData.members || [])
       }
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching small group details:", error)
       toast({
         title: "Error",

--- a/app/(dashboard)/small-groups/page.tsx
+++ b/app/(dashboard)/small-groups/page.tsx
@@ -142,7 +142,7 @@ export default function SmallGroupsPage() {
         if (!parentCenterName) setParentCenterName(data.smallGroups[0].clusterId?.centerId?.name || null);
       }
 
-    } catch (error: any) {
+    } catch (error: Error) {
       console.error("Error fetching small groups:", error)
       toast({
         title: "Error",
@@ -154,7 +154,7 @@ export default function SmallGroupsPage() {
     } finally {
       setIsLoading(false)
     }
-  }, [pagination.limit, toast, user, canViewAnySmallGroup, parentClusterName, parentCenterName])
+  }, [pagination.limit, toast, user, canViewAnySmallGroup, parentClusterName, parentCenterName, smallGroups])
 
   useEffect(() => {
     const page = parseInt(searchParams.get("page") || "1")
@@ -171,7 +171,6 @@ export default function SmallGroupsPage() {
     if (user) {
         fetchSmallGroups(page, search, clusterIdFromQuery)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, user, fetchSmallGroups])
 
   const handleSearch = (e: React.FormEvent) => {


### PR DESCRIPTION
This commit continues addressing ESLint and TypeScript errors identified in the build log.

Changes made:

- Resolved linting errors in the following files:
    - `app/(dashboard)/flyers/page.tsx`: Replaced `any` type in function parameters with more specific types.
    - `app/(dashboard)/follow-ups/[id]/page.tsx`: Removed unused import (`DialogTrigger`), commented out unused variable (`router`), replaced `any` types, and corrected usage of underscore variables.
    - `app/(dashboard)/follow-ups/new/page.tsx`: Removed unused import (`CardFooter`) and renamed unused function parameters (`_values`).
    - `app/(dashboard)/follow-ups/page.tsx`: Removed unused imports (`Filter`, `UserCheck`), added missing `useEffect` dependency (`fetchFollowUps`), changed `let` to `const` for `queryParams`, and replaced `any` types.
    - `app/(dashboard)/groups/[id]/dashboard/page.tsx`: Typed an error object (`error: Error`) and escaped an apostrophe.
    - `app/(dashboard)/members/page.tsx`: Added missing `useEffect` dependency (`fetchMembers`).
    - `app/(dashboard)/members/spiritual-growth-tab.tsx`: Added missing `useEffect` dependency (`fetchSpiritualGrowth`) and used `unknown` with a type guard for an `any` type.
    - `app/(dashboard)/small-groups/[id]/page.tsx`: Typed an error object.
    - `app/(dashboard)/small-groups/page.tsx`: Typed an error object, added missing `useCallback` dependency (`smallGroups`), and removed an unused `eslint-disable` directive.

This commit represents the completion of steps 10 through 18 of the plan. Work is ongoing to resolve the remaining linting issues and then address the functionality of the follow-up page.